### PR TITLE
(CodeRabbit test#2) Feat/eval mvmap

### DIFF
--- a/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
+++ b/core/src/main/java/org/opensearch/sql/calcite/CalcitePlanContext.java
@@ -194,7 +194,10 @@ public class CalcitePlanContext {
 
     // Create a lambda ref for this captured variable
     // The index is offset by the number of lambda parameters (1 for single-param lambda)
-    int lambdaParamCount = rexLambdaRefMap.size();
+    // Count only actual lambda parameters, not captured variables
+    int lambdaParamCount =
+        (int)
+            rexLambdaRefMap.keySet().stream().filter(key -> !key.startsWith("__captured_")).count();
     RexLambdaRef lambdaRef =
         new RexLambdaRef(lambdaParamCount + captureIndex, fieldName, fieldRef.getType());
 

--- a/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/BuiltinFunctionName.java
@@ -78,6 +78,7 @@ public enum BuiltinFunctionName {
   MVZIP(FunctionName.of("mvzip")),
   SPLIT(FunctionName.of("split")),
   MVDEDUP(FunctionName.of("mvdedup")),
+  MVMAP(FunctionName.of("mvmap")),
   FORALL(FunctionName.of("forall")),
   EXISTS(FunctionName.of("exists")),
   FILTER(FunctionName.of("filter")),

--- a/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/TransformFunctionImpl.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/CollectionUDF/TransformFunctionImpl.java
@@ -98,6 +98,12 @@ public class TransformFunctionImpl extends ImplementorUDF {
       try {
         if (hasCapturedVars) {
           // Lambda has captured variables - pass the first captured variable as second arg
+          // LIMITATION: Currently only the first captured variable (args[2]) is supported.
+          // Supporting multiple captured variables would require either:
+          // 1. Packing args[2..args.length-1] into an Object[] and modifying lambda generation
+          //    to accept a container as the second parameter, or
+          // 2. Using higher-arity function interfaces (Function3, Function4, etc.)
+          // For now, lambdas that capture multiple external variables may not work correctly.
           Object capturedVar = args[2];
           for (Object candidate : target) {
             results.add(

--- a/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
+++ b/core/src/main/java/org/opensearch/sql/expression/function/PPLFuncImpTable.java
@@ -154,6 +154,7 @@ import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVAPPEN
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVDEDUP;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVINDEX;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVJOIN;
+import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVMAP;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.MVZIP;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.NOT;
 import static org.opensearch.sql.expression.function.BuiltinFunctionName.NOTEQUAL;
@@ -1037,6 +1038,7 @@ public class PPLFuncImpTable {
       registerOperator(MVAPPEND, PPLBuiltinOperators.MVAPPEND);
       registerOperator(MVDEDUP, SqlLibraryOperators.ARRAY_DISTINCT);
       registerOperator(MVZIP, PPLBuiltinOperators.MVZIP);
+      registerOperator(MVMAP, PPLBuiltinOperators.TRANSFORM);
       registerOperator(MAP_APPEND, PPLBuiltinOperators.MAP_APPEND);
       registerOperator(MAP_CONCAT, SqlLibraryOperators.MAP_CONCAT);
       registerOperator(MAP_REMOVE, PPLBuiltinOperators.MAP_REMOVE);

--- a/docs/user/ppl/functions/collection.md
+++ b/docs/user/ppl/functions/collection.md
@@ -772,6 +772,26 @@ fetched rows / total rows = 1/1
 
 Note: For nested expressions like ``mvmap(mvindex(arr, 1, 3), arr * 2)``, the field name (``arr``) is extracted from the first argument and must match the field referenced in the expression.
 
+The expression can also reference other single-value fields:
+
+```ppl
+source=people
+| eval array = array(1, 2, 3), multiplier = 10, result = mvmap(array, array * multiplier)
+| fields result
+| head 1
+```
+
+Expected output:
+
+```text
+fetched rows / total rows = 1/1
++------------+
+| result     |
+|------------|
+| [10,20,30] |
++------------+
+```
+
 
 ## MVZIP
 

--- a/docs/user/ppl/functions/collection.md
+++ b/docs/user/ppl/functions/collection.md
@@ -725,6 +725,54 @@ fetched rows / total rows = 1/1
 +--------------------------+
 ```
 
+## MVMAP
+
+### Description
+
+Usage: mvmap(array, expression) iterates over each element of a multivalue array, applies the expression to each element, and returns a multivalue array with the transformed results. The field name in the expression is implicitly bound to each element value.
+Argument type: array: ARRAY, expression: EXPRESSION
+Return type: ARRAY
+Example
+
+```ppl
+source=people
+| eval array = array(1, 2, 3), result = mvmap(array, array * 10)
+| fields result
+| head 1
+```
+
+Expected output:
+
+```text
+fetched rows / total rows = 1/1
++------------+
+| result     |
+|------------|
+| [10,20,30] |
++------------+
+```
+
+```ppl
+source=people
+| eval array = array(1, 2, 3), result = mvmap(array, array + 5)
+| fields result
+| head 1
+```
+
+Expected output:
+
+```text
+fetched rows / total rows = 1/1
++---------+
+| result  |
+|---------|
+| [6,7,8] |
++---------+
+```
+
+Note: For nested expressions like ``mvmap(mvindex(arr, 1, 3), arr * 2)``, the field name (``arr``) is extracted from the first argument and must match the field referenced in the expression.
+
+
 ## MVZIP
 
 ### Description

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -701,4 +701,21 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
     verifySchema(actual, schema("result", "array"));
     verifyDataRows(actual, rows(List.of(6, 7, 8)));
   }
+
+  @Test
+  public void testMvmapWithNestedFunction() throws IOException {
+    // Test mvmap with mvindex as first argument - extracts field name from nested function
+    // Equivalent to Splunk: mvmap(mvindex(arr, 1, 3), arr * 10)
+    // The lambda binds 'arr' and iterates over mvindex output (values at indices 1-3)
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array(10, 20, 30, 40, 50), result = mvmap(mvindex(arr, 1,"
+                    + " 3), arr * 2) | head 1 | fields result",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "array"));
+    // mvindex(arr, 1, 3) returns [20, 30, 40], then mvmap multiplies each by 2
+    verifyDataRows(actual, rows(List.of(40, 60, 80)));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -675,4 +675,30 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
     // Empty delimiter splits into individual characters
     verifyDataRows(actual, rows(List.of("a", "b", "c", "d")));
   }
+
+  @Test
+  public void testMvmap() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array(1, 2, 3), result = mvmap(arr, arr * 10) | head 1 |"
+                    + " fields result",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "array"));
+    verifyDataRows(actual, rows(List.of(10, 20, 30)));
+  }
+
+  @Test
+  public void testMvmapWithAddition() throws IOException {
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array(1, 2, 3), result = mvmap(arr, arr + 5) | head 1 |"
+                    + " fields result",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "array"));
+    verifyDataRows(actual, rows(List.of(6, 7, 8)));
+  }
 }

--- a/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
+++ b/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalciteArrayFunctionIT.java
@@ -718,4 +718,34 @@ public class CalciteArrayFunctionIT extends PPLIntegTestCase {
     // mvindex(arr, 1, 3) returns [20, 30, 40], then mvmap multiplies each by 2
     verifyDataRows(actual, rows(List.of(40, 60, 80)));
   }
+
+  @Test
+  public void testMvmapWithOtherFieldReference() throws IOException {
+    // Test mvmap with reference to another field in the expression
+    // The first record in bank has age=32, so array(1,2,3) * 32 = [32, 64, 96]
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array(1, 2, 3), result = mvmap(arr, arr * age) | head 1 |"
+                    + " fields age, result",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("age", "int"), schema("result", "array"));
+    verifyDataRows(actual, rows(32, List.of(32, 64, 96)));
+  }
+
+  @Test
+  public void testMvmapWithEvalFieldReference() throws IOException {
+    // Test mvmap with reference to another field created by eval
+    // array(1,2,3) * 10 = [10, 20, 30]
+    JSONObject actual =
+        executeQuery(
+            String.format(
+                "source=%s | eval arr = array(1, 2, 3), multiplier = 10, result = mvmap(arr, arr *"
+                    + " multiplier) | head 1 | fields result",
+                TEST_INDEX_BANK));
+
+    verifySchema(actual, schema("result", "array"));
+    verifyDataRows(actual, rows(List.of(10, 20, 30)));
+  }
 }

--- a/ppl/src/main/antlr/OpenSearchPPLLexer.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLLexer.g4
@@ -455,6 +455,7 @@ MVINDEX:                            'MVINDEX';
 MVZIP:                              'MVZIP';
 MVDEDUP:                            'MVDEDUP';
 SPLIT:                              'SPLIT';
+MVMAP:                              'MVMAP';
 FORALL:                             'FORALL';
 FILTER:                             'FILTER';
 TRANSFORM:                          'TRANSFORM';

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -1127,6 +1127,7 @@ collectionFunctionName
     | MVDEDUP
     | MVZIP
     | SPLIT
+    | MVMAP
     | FORALL
     | EXISTS
     | FILTER

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -1132,7 +1132,6 @@ collectionFunctionName
     | MVDEDUP
     | MVZIP
     | SPLIT
-    | MVMAP
     | FORALL
     | EXISTS
     | FILTER

--- a/ppl/src/main/antlr/OpenSearchPPLParser.g4
+++ b/ppl/src/main/antlr/OpenSearchPPLParser.g4
@@ -849,13 +849,18 @@ evalExpression
     ;
 
 functionCall
-   : evalFunctionCall
+   : mvmapFunctionCall
+   | evalFunctionCall
    | dataTypeFunctionCall
    | positionFunctionCall
    | caseFunctionCall
    | timestampFunctionCall
    | extractFunctionCall
    | getFormatFunctionCall
+   ;
+
+mvmapFunctionCall
+   : MVMAP LT_PRTHS functionArg COMMA functionArg RT_PRTHS
    ;
 
 positionFunctionCall

--- a/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/parser/AstExpressionBuilder.java
@@ -504,9 +504,12 @@ public class AstExpressionBuilder extends OpenSearchPPLParserBaseVisitor<Unresol
 
         @Override
         public QualifiedName visitFunction(Function node, Void context) {
-          List<UnresolvedExpression> funcArgs = node.getFuncArgs();
-          if (!funcArgs.isEmpty()) {
-            return funcArgs.get(0).accept(this, context);
+          // Visit each funcArg and return on first non-null (qualified name found)
+          for (UnresolvedExpression arg : node.getFuncArgs()) {
+            QualifiedName result = arg.accept(this, context);
+            if (result != null) {
+              return result;
+            }
           }
           return null;
         }

--- a/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
+++ b/ppl/src/main/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizer.java
@@ -42,6 +42,7 @@ import org.opensearch.sql.ast.expression.Field;
 import org.opensearch.sql.ast.expression.Function;
 import org.opensearch.sql.ast.expression.In;
 import org.opensearch.sql.ast.expression.Interval;
+import org.opensearch.sql.ast.expression.LambdaFunction;
 import org.opensearch.sql.ast.expression.Let;
 import org.opensearch.sql.ast.expression.Literal;
 import org.opensearch.sql.ast.expression.Map;
@@ -914,11 +915,31 @@ public class PPLQueryDataAnonymizer extends AbstractNodeVisitor<String, String> 
 
     @Override
     public String visitFunction(Function node, String context) {
+      // For mvmap, unwrap the implicit lambda to show original format
+      if ("mvmap".equalsIgnoreCase(node.getFuncName())
+          && node.getFuncArgs().size() == 2
+          && node.getFuncArgs().get(1) instanceof LambdaFunction) {
+        String firstArg = analyze(node.getFuncArgs().get(0), context);
+        LambdaFunction lambda = (LambdaFunction) node.getFuncArgs().get(1);
+        String lambdaBody = analyze(lambda.getFunction(), context);
+        return StringUtils.format("%s(%s,%s)", node.getFuncName(), firstArg, lambdaBody);
+      }
+
       String arguments =
           node.getFuncArgs().stream()
               .map(unresolvedExpression -> analyze(unresolvedExpression, context))
               .collect(Collectors.joining(","));
       return StringUtils.format("%s(%s)", node.getFuncName(), arguments);
+    }
+
+    @Override
+    public String visitLambdaFunction(LambdaFunction node, String context) {
+      String args =
+          node.getFuncArgs().stream()
+              .map(arg -> maskField(arg.toString()))
+              .collect(Collectors.joining(","));
+      String function = analyze(node.getFunction(), context);
+      return StringUtils.format("%s -> %s", args, function);
     }
 
     @Override

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
@@ -504,4 +504,35 @@ public class CalcitePPLArrayFunctionTest extends CalcitePPLAbstractTest {
             + "LIMIT 1";
     verifyPPLToSparkSQL(root, expectedSparkSql);
   }
+
+  @Test
+  public void testMvmapBasic() {
+    String ppl =
+        "source=EMP | eval arr = array(1, 2, 3), result = mvmap(arr, arr * 10) | head 1 |"
+            + " fields result";
+    RelNode root = getRelNode(ppl);
+
+    String expectedLogical =
+        "LogicalProject(result=[$9])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], arr=[array(1, 2, 3)],"
+            + " result=[transform(array(1, 2, 3), (arr) -> *(arr, 10))])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedResult = "result=[10, 20, 30]\n";
+    verifyResult(root, expectedResult);
+  }
+
+  @Test
+  public void testMvmapWithAddition() {
+    String ppl =
+        "source=EMP | eval arr = array(1, 2, 3), result = mvmap(arr, arr + 5) | head 1 |"
+            + " fields result";
+    RelNode root = getRelNode(ppl);
+
+    String expectedResult = "result=[6, 7, 8]\n";
+    verifyResult(root, expectedResult);
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/calcite/CalcitePPLArrayFunctionTest.java
@@ -521,8 +521,11 @@ public class CalcitePPLArrayFunctionTest extends CalcitePPLAbstractTest {
             + "      LogicalTableScan(table=[[scott, EMP]])\n";
     verifyLogical(root, expectedLogical);
 
-    String expectedResult = "result=[10, 20, 30]\n";
-    verifyResult(root, expectedResult);
+    String expectedSparkSql =
+        "SELECT TRANSFORM(ARRAY(1, 2, 3), `arr` -> `arr` * 10) `result`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 
   @Test
@@ -532,7 +535,19 @@ public class CalcitePPLArrayFunctionTest extends CalcitePPLAbstractTest {
             + " fields result";
     RelNode root = getRelNode(ppl);
 
-    String expectedResult = "result=[6, 7, 8]\n";
-    verifyResult(root, expectedResult);
+    String expectedLogical =
+        "LogicalProject(result=[$9])\n"
+            + "  LogicalSort(fetch=[1])\n"
+            + "    LogicalProject(EMPNO=[$0], ENAME=[$1], JOB=[$2], MGR=[$3], HIREDATE=[$4],"
+            + " SAL=[$5], COMM=[$6], DEPTNO=[$7], arr=[array(1, 2, 3)],"
+            + " result=[transform(array(1, 2, 3), (arr) -> +(arr, 5))])\n"
+            + "      LogicalTableScan(table=[[scott, EMP]])\n";
+    verifyLogical(root, expectedLogical);
+
+    String expectedSparkSql =
+        "SELECT TRANSFORM(ARRAY(1, 2, 3), `arr` -> `arr` + 5) `result`\n"
+            + "FROM `scott`.`EMP`\n"
+            + "LIMIT 1";
+    verifyPPLToSparkSQL(root, expectedSparkSql);
   }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -1627,16 +1627,11 @@ public class AstBuilderTest {
 
   @Test
   public void testMvmapWithWrongNumberOfArgsThrowsException() {
-    assertEquals(
-        "mvmap requires exactly 2 arguments",
-        assertThrows(SyntaxCheckException.class, () -> plan("source=t | eval result = mvmap(arr)"))
-            .getMessage());
-    assertEquals(
-        "mvmap requires exactly 2 arguments",
-        assertThrows(
-                SyntaxCheckException.class,
-                () -> plan("source=t | eval result = mvmap(arr, arr * 10, extra)"))
-            .getMessage());
+    // Grammar enforces exactly 2 arguments, so parser throws syntax error
+    assertThrows(SyntaxCheckException.class, () -> plan("source=t | eval result = mvmap(arr)"));
+    assertThrows(
+        SyntaxCheckException.class,
+        () -> plan("source=t | eval result = mvmap(arr, arr * 10, extra)"));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/parser/AstBuilderTest.java
@@ -1614,4 +1614,38 @@ public class AstBuilderTest {
             .contains(
                 "Span length [2.5y] is invalid: floating-point time intervals are not supported."));
   }
+
+  @Test
+  public void testMvmapWithLambdaSecondArgThrowsException() {
+    assertEquals(
+        "mvmap does not accept lambda expression as second argument",
+        assertThrows(
+                SyntaxCheckException.class,
+                () -> plan("source=t | eval result = mvmap(arr, x -> x * 10)"))
+            .getMessage());
+  }
+
+  @Test
+  public void testMvmapWithWrongNumberOfArgsThrowsException() {
+    assertEquals(
+        "mvmap requires exactly 2 arguments",
+        assertThrows(SyntaxCheckException.class, () -> plan("source=t | eval result = mvmap(arr)"))
+            .getMessage());
+    assertEquals(
+        "mvmap requires exactly 2 arguments",
+        assertThrows(
+                SyntaxCheckException.class,
+                () -> plan("source=t | eval result = mvmap(arr, arr * 10, extra)"))
+            .getMessage());
+  }
+
+  @Test
+  public void testMvmapWithNonFieldFirstArgThrowsException() {
+    assertEquals(
+        "mvmap first argument must be a field or field expression",
+        assertThrows(
+                SyntaxCheckException.class,
+                () -> plan("source=t | eval result = mvmap(123, 123 * 10)"))
+            .getMessage());
+  }
 }

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -900,9 +900,9 @@ public class PPLQueryDataAnonymizerTest {
   @Test
   public void testMvmap() {
     assertEquals(
-        "source=table | eval identifier=mvmap(array(***,***,***),*(identifier,***)) | fields +"
+        "source=table | eval identifier=mvmap(identifier,*(identifier,***)) | fields +"
             + " identifier",
-        anonymize("source=t | eval result=mvmap(array(1, 2, 3), arr * 10) | fields result"));
+        anonymize("source=t | eval result=mvmap(arr, arr * 10) | fields result"));
   }
 
   @Test

--- a/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
+++ b/ppl/src/test/java/org/opensearch/sql/ppl/utils/PPLQueryDataAnonymizerTest.java
@@ -898,6 +898,14 @@ public class PPLQueryDataAnonymizerTest {
   }
 
   @Test
+  public void testMvmap() {
+    assertEquals(
+        "source=table | eval identifier=mvmap(array(***,***,***),*(identifier,***)) | fields +"
+            + " identifier",
+        anonymize("source=t | eval result=mvmap(array(1, 2, 3), arr * 10) | fields result"));
+  }
+
+  @Test
   public void testRexWithOffsetField() {
     when(settings.getSettingValue(Key.PPL_REX_MAX_MATCH_LIMIT)).thenReturn(10);
 


### PR DESCRIPTION
## **Description**

This PR adds support for the `mvmap` eval function, which iterates over each element of a multivalue array, applies a given expression, and returns a new array containing the transformed results.

**Syntax:**  
`mvmap(array, expression)`

During iteration, the field name in the expression is implicitly bound to each element of the input array (e.g., `mvmap(arr, arr * 10)`).

---

## **Implementation Details**

### **Core Approach**

`mvmap` is implemented as an alias for PPL's existing `TRANSFORM` operator, which applies a lambda function to each array element.

To support implicit binding syntax—`mvmap(arr, arr * 10)` instead of requiring explicit lambda syntax (`mvmap(arr, x -> x * 10)`)—AST transformation logic was added in `AstExpressionBuilder.java`.

### **AST Transformation Steps**

1. Intercept `mvmap` function calls in `visitEvalFunctionCall()`
2. Extract the field name from the first argument (e.g., `arr`)
3. Wrap the second argument expression into a `LambdaFunction`, using the extracted field name as the parameter
4. Transform:


### Check List
- [x] New functionality includes testing.
- [x] New functionality has been documented.
 - [x] New functionality has javadoc added.
 - [x] New functionality has a user manual doc added.
- [ ] New PPL command [checklist](https://github.com/opensearch-project/sql/blob/main/docs/dev/ppl-commands.md) all confirmed.
- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
- [x] Commits are signed per the DCO using `--signoff` or `-s`.
- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/sql/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).